### PR TITLE
Bouton de zoom sur la timeline supprimé

### DIFF
--- a/js/timeline-zoomable.js
+++ b/js/timeline-zoomable.js
@@ -26,7 +26,8 @@ function initializeTimeline(data) {
 	timelineWidth = container.node().offsetWidth - margin.left - margin.right;
 	timelineHeight = container.node().offsetHeight - margin.top - margin.bottom - /* scroll */ 15;
 	window.onresize = function(event) {
-		container.node().innerHTML = '';
+		var svg = container.select('svg').node();
+		container.node().removeChild(svg);
 		initializeTimeline(data);
 	};
 


### PR DESCRIPTION
Lors du redimensionnement on ne supprime que la partie svg du nœud parent au lien de la totalité pour garder les bouton de zoom
